### PR TITLE
Attempt to delete dictcc buffer upon opening a new

### DIFF
--- a/plugin/dictcc.vim
+++ b/plugin/dictcc.vim
@@ -15,7 +15,8 @@ python3 << endOfPython
 from dictcc import DictQuery
 
 def create_new_buffer(contents):
-    vim.command('rightbelow split dictcc')
+    vim.command('silent! :bdelete [dictcc]')
+    vim.command('rightbelow split [dictcc]')
     vim.command('normal! ggdG')
     vim.command('setlocal filetype=dictcc')
     vim.command('call append(0, {0})'.format(contents))


### PR DESCRIPTION
Issuing a `:Dict` command while a previous `dictcc` buffer was still open resulted in non-intuitive behavior (see #3 )
Attempt to unload the previous buffer before opening a new one