### PR TITLE
Do not treat the `[dictcc]` buffer name as regex

### DIFF
--- a/plugin/dictcc.vim
+++ b/plugin/dictcc.vim
@@ -15,7 +15,7 @@ python3 << endOfPython
 from dictcc import DictQuery
 
 def create_new_buffer(contents):
-    vim.command('silent! :bdelete [dictcc]')
+    vim.command('silent! bdelete \V[dictcc]')
     vim.command('rightbelow split [dictcc]')
     vim.command('normal! ggdG')
     vim.command('setlocal filetype=dictcc')


### PR DESCRIPTION
Depending on the user's `magic` setting, the vim command `bdelete [dictcc]` treats its argument `[dictcc]` like a regular expression, effectively closing every buffer which has a `c`, `d`, `i` or `t` in its name. Prepand `\V` to force `very no magic` mode and treat `[dictcc]` as literal name instead.