### PR TITLE
Correctly escape `\` in the Python string `\V` (`\\V`)

### DIFF
--- a/plugin/dictcc.vim
+++ b/plugin/dictcc.vim
@@ -15,7 +15,7 @@ python3 << endOfPython
 from dictcc import DictQuery
 
 def create_new_buffer(contents):
-    vim.command('silent! bdelete \V[dictcc]')
+    vim.command('silent! bdelete \\V[dictcc]')
     vim.command('rightbelow split [dictcc]')
     vim.command('normal! ggdG')
     vim.command('setlocal filetype=dictcc')


### PR DESCRIPTION
Since Python 3.12 wrong escapes are emitted as Syntax warning, effectively breaking this plugin. Thus, fix the wrong escape in the Python code.